### PR TITLE
Add support for operators and numbers in tokenizer, acc to #1

### DIFF
--- a/hello.x
+++ b/hello.x
@@ -1,2 +1,3 @@
 print("Hello World")
-"Bye World"
+print(3.14)
+print(1 + 2)

--- a/x/parser/parser.py
+++ b/x/parser/parser.py
@@ -34,7 +34,7 @@ class Parser:
     def __number(self):
         number_token = self.__expect("__number__")
 
-        return number_token.value, "int"
+        return number_token.value, number_token.dtype
 
     def __term(self):
         if self.__peek().type == "__number__":
@@ -62,14 +62,15 @@ class Parser:
     def __sum(self):
         expr, dtype = self.__mul()
 
-        while self.__peek().type in ["__plus__", "__minus__"]:
+        op_type_to_operator = {"__add__": "+", "__sub__": "-", "__mul__": "*", "__div__": "/"}
+        while self.__peek().type in ["__add__", "__sub__"]:
             op = self.__consume()
             right_expr, right_dtype = self.__mul()
 
             if dtype != right_dtype:
                 raise ParseError(f"Type mismatch: {dtype} and {right_dtype}")
 
-            expr = f"({expr} {op.type} {right_expr})"
+            expr = f"{expr} {op_type_to_operator[op.type]} {right_expr}"
 
         return expr, dtype
 

--- a/x/tokenizer/tokenizer.py
+++ b/x/tokenizer/tokenizer.py
@@ -1,7 +1,8 @@
 from collections import namedtuple
+from ..utils.error import TokenizerError
 
 
-Token = namedtuple("Token", ["type", "value", "line_num"])
+Token = namedtuple("Token", ["type", "dtype", "value", "line_num"])
 
 
 class Tokenizer:
@@ -31,6 +32,7 @@ class Tokenizer:
         return "__string__"
 
     def __is_number(self):
+        is_float = False
         while (
             self.__source[self.__pointer].isdigit()
             or self.__source[self.__pointer] == "."
@@ -40,34 +42,56 @@ class Tokenizer:
 
         self.__pointer -= 1
 
-        return "__number__"
+        if self.__lexeme.count(".") > 1:
+            raise TokenizerError(message="A number cannot have more than one decimal points!")
+
+        if self.__lexeme.count(".") == 1:
+            is_float = True
+
+        return "__number__", "float" if is_float else "int"
+
+    def __operator(self):
+        if self.__source[self.__pointer] == "+":
+            return "__add__"
+        elif self.__source[self.__pointer] == "-":
+            return "__sub__"
+        elif self.__source[self.__pointer] == "*":
+            return "__mul__"
+        elif self.__source[self.__pointer] == "/":
+            return "__div__"
 
     def generate_tokens(self):
         while self.__pointer < len(self.__source):
             self.__lexeme = ""
             if self.__source[self.__pointer].isalpha():
                 self.__tokens.append(
-                    Token(self.__is_keyword(), self.__lexeme, self.__line_num)
+                    Token(self.__is_keyword(), "", self.__lexeme, self.__line_num)
                 )
             elif self.__source[self.__pointer] == "(":
-                self.__tokens.append(Token("__left_paren__", "", self.__line_num))
+                self.__tokens.append(Token("__left_paren__", "", "", self.__line_num))
             elif self.__source[self.__pointer] == ")":
-                self.__tokens.append(Token("__right_paren__", "", self.__line_num))
+                self.__tokens.append(Token("__right_paren__", "", "", self.__line_num))
+            elif self.__source[self.__pointer] in ["+", "-", "*", "/"]:
+                operator = self.__operator()
+                self.__tokens.append(
+                    Token(operator, "", self.__source[self.__pointer], self.__line_num)
+                )
             elif self.__source[self.__pointer] == '"':
                 self.__tokens.append(
-                    Token(self.__is_string(), self.__lexeme, self.__line_num)
+                    Token(self.__is_string(), "string", self.__lexeme, self.__line_num)
                 )
             elif self.__source[self.__pointer].isdigit():
+                number, dtype = self.__is_number()
                 self.__tokens.append(
-                    Token(self.__is_number(), self.__lexeme, self.__line_num)
+                    Token(number, dtype, self.__lexeme, self.__line_num)
                 )
             elif self.__source[self.__pointer] == "\n":
                 self.__line_num += 1
-                self.__tokens.append(Token("__newline__", "", self.__line_num - 1))
+                self.__tokens.append(Token("__newline__", "", "", self.__line_num - 1))
 
             self.__pointer += 1
 
-        self.__tokens.append(Token("__newline__", "", self.__line_num))
-        self.__tokens.append(Token("__eof__", "", self.__line_num + 1))
+        self.__tokens.append(Token("__newline__",  "", "", self.__line_num))
+        self.__tokens.append(Token("__eof__", "", "", self.__line_num + 1))
 
         return self.__tokens

--- a/x/utils/error.py
+++ b/x/utils/error.py
@@ -8,6 +8,12 @@ class Error(Exception):
     def message(self):
         return self.__message
 
+class TokenizerError(Error):
+    def __init__(self, message):
+        super().__init__(message)
+
+    def __str__(self):
+        return f"\033[91mError:\033[m {self.message}!"
 
 class ParseError(Error):
     def __init__(self, message):


### PR DESCRIPTION
Closes #2 

**Implementation**

1. Identify numbers (int and float) in tokenizer. Support for double will be added in #10.

2. Identify operators (+, -, *, /) in tokenizer.

3. Add support for the same in the parser, change the dtype in __number and map the operator tokens to actual operators.