### PR TITLE
In 12

### DIFF
--- a/hello.x
+++ b/hello.x
@@ -1,3 +1,3 @@
 print("Hello World")
 print(3.14)
-print(1 + 2)
+print(1 + 2 * 3)

--- a/x/parser/node/binary_operator_node.py
+++ b/x/parser/node/binary_operator_node.py
@@ -1,0 +1,20 @@
+class BinaryOperatorNode:
+    def __init__(self, operator, left, right):
+        self.__operator = operator
+        self.__left = left
+        self.__right = right
+
+    @property
+    def operator(self):
+        return self.__operator
+
+    @property
+    def left(self):
+        return self.__left
+
+    @property
+    def right(self):
+        return self.__right
+
+    def __str__(self):
+        return f"BinaryOperatorNode(operator={self.__operator}, left={str(self.__left)}, right={str(self.__right)})"

--- a/x/parser/node/string_node.py
+++ b/x/parser/node/string_node.py
@@ -1,4 +1,4 @@
-class NumberNode:
+class StringNode:
     def __init__(self, value):
         self.__value = value
 
@@ -7,4 +7,4 @@ class NumberNode:
         return self.__value
 
     def __str__(self):
-        return f"NumberNode(value={self.__value})"
+        return f"StringNode(value={self.__value})"

--- a/x/parser/parser.py
+++ b/x/parser/parser.py
@@ -48,21 +48,22 @@ class Parser:
     def __mul(self):
         expr, dtype = self.__factor()
 
+        op_type_to_operator = {"__mul__": "*", "__div__": "/"}
         while self.__peek().type in ["__mul__", "__div__"]:
             op = self.__consume()
-            right_expr, right_dtype = self.__primary()
+            right_expr, right_dtype = self.__mul()
 
             if dtype != right_dtype:
                 raise ParseError(f"Type mismatch: {dtype} and {right_dtype}")
 
-            expr = f"({expr} {op.type} {right_expr})"
+            expr = f"({expr} {op_type_to_operator[op.type]} {right_expr})"
 
         return expr, dtype
 
     def __sum(self):
         expr, dtype = self.__mul()
 
-        op_type_to_operator = {"__add__": "+", "__sub__": "-", "__mul__": "*", "__div__": "/"}
+        op_type_to_operator = {"__add__": "+", "__sub__": "-"}
         while self.__peek().type in ["__add__", "__sub__"]:
             op = self.__consume()
             right_expr, right_dtype = self.__mul()
@@ -70,7 +71,7 @@ class Parser:
             if dtype != right_dtype:
                 raise ParseError(f"Type mismatch: {dtype} and {right_dtype}")
 
-            expr = f"{expr} {op_type_to_operator[op.type]} {right_expr}"
+            expr = f"({expr} {op_type_to_operator[op.type]} {right_expr})"
 
         return expr, dtype
 

--- a/x/parser/parser.py
+++ b/x/parser/parser.py
@@ -1,3 +1,6 @@
+from .node.number_node import NumberNode
+from .node.string_node import StringNode
+from .node.binary_operator_node import BinaryOperatorNode
 from .node.program_node import ProgramNode
 from .node.print_node import PrintNode
 from .node.expr_node import ExprNode
@@ -29,12 +32,12 @@ class Parser:
     def __string(self):
         string_token = self.__expect("__string__")
 
-        return string_token.value, "string"
+        return StringNode(value=string_token.value), "string"
 
     def __number(self):
         number_token = self.__expect("__number__")
 
-        return number_token.value, number_token.dtype
+        return NumberNode(value=number_token.value), number_token.dtype
 
     def __term(self):
         if self.__peek().type == "__number__":
@@ -56,7 +59,7 @@ class Parser:
             if dtype != right_dtype:
                 raise ParseError(f"Type mismatch: {dtype} and {right_dtype}")
 
-            expr = f"({expr} {op_type_to_operator[op.type]} {right_expr})"
+            expr = BinaryOperatorNode(operator=op_type_to_operator[op.type], left=expr, right=right_expr)
 
         return expr, dtype
 
@@ -71,7 +74,7 @@ class Parser:
             if dtype != right_dtype:
                 raise ParseError(f"Type mismatch: {dtype} and {right_dtype}")
 
-            expr = f"({expr} {op_type_to_operator[op.type]} {right_expr})"
+            expr = BinaryOperatorNode(operator=op_type_to_operator[op.type], left=expr, right=right_expr)
 
         return expr, dtype
 


### PR DESCRIPTION
Closes #12 

**Implementation**

1. Add node classes for number, string and operator.
2. Return number node and string node from __number and __string instead of the raw values.
3. Do the same for expressions, instead of returning the raw expressions return the tree of operations from both __mul and __sum.
4. This then represents the numbers and all operations on them as a tree like structure (which is ideal for an AST) rather than a raw string which is useless when it comes to executing the expression.