### PR TITLE
Add support for new grammar and a stack based C decompiler

### DIFF
--- a/x/decompiler/c/decompile.py
+++ b/x/decompiler/c/decompile.py
@@ -1,11 +1,23 @@
+from collections import namedtuple
+
 from ...opcode.op_type import OpType
 
+
+const_val = namedtuple("Const", ["value", "dtype"])
 
 class CDecompiler:
     def __init__(self, opcodes):
         self.__opcodes = opcodes
 
+        self.__constant_pool = []
+
         self.__decompiled_code = []
+
+    def __pop(self):
+        return self.__constant_pool.pop()
+
+    def __push(self, value):
+        self.__constant_pool.append(value)
 
     def __add_includes(self):
         includes = []
@@ -16,14 +28,34 @@ class CDecompiler:
 
         self.__decompiled_code.extend(list(set(includes)))
 
-    def __decompile_print(self, opcode):
+    def __decompile_print(self):
         print_string = "\tprintf("
-        if opcode.op_dtype == "string":
-            print_string += f'"%s\\n", "{opcode.op_value}"'
-        elif opcode.op_dtype == "number":
-            print_string += f'"%d\\n", {opcode.op_value}'
+        top_const = self.__constant_pool.pop()
+
+        if top_const.dtype == "string":
+            print_string += f'"%s\\n", "{top_const.value}"'
+        elif top_const.dtype == "int":
+            print_string += f'"%d\\n", {top_const.value}'
+        elif top_const.dtype == "float":
+            print_string += f'"%f\\n", {top_const.value}'
 
         return print_string + ");"
+
+    def __decompile_binary_operation(self, opcode):
+        right = self.__constant_pool.pop()
+        left = self.__constant_pool.pop()
+
+        result = ""
+        if opcode.opcode == OpType.ADD:
+            result = f"{left.value} + {right.value};"
+        elif opcode.opcode == OpType.SUB:
+            result = f"{left.value} - {right.value};"
+        elif opcode.opcode == OpType.MUL:
+            result = f"{left.value} * {right.value};"
+        elif opcode.opcode == OpType.DIV:
+            result = f"{left.value} / {right.value};"
+
+        self.__push(const_val(value=result, dtype=left.dtype))
 
     def decompile(self):
         self.__add_includes()
@@ -31,7 +63,11 @@ class CDecompiler:
         self.__decompiled_code.append("int main() {")
         for opcode in self.__opcodes:
             if opcode.opcode == OpType.PRINT:
-                self.__decompiled_code.append(self.__decompile_print(opcode))
+                self.__decompiled_code.append(self.__decompile_print())
+            elif opcode.opcode == OpType.LOAD:
+                self.__constant_pool.append(const_val(opcode.op_value, opcode.op_dtype))
+            elif opcode.opcode in [OpType.ADD, OpType.SUB, OpType.MUL, OpType.DIV]:
+                self.__decompile_binary_operation(opcode)
 
         self.__decompiled_code.append("\n\treturn 0; \n}")
         return self.__decompiled_code

--- a/x/vm/vm.py
+++ b/x/vm/vm.py
@@ -8,10 +8,7 @@ class VM:
         self.__constant_pool = []
 
     def __pop(self):
-        constant = self.__constant_pool[-1]
-        self.__constant_pool.pop()
-
-        return constant
+        return self.__constant_pool.pop()
 
     def __push(self, constant):
         self.__constant_pool.append(constant)


### PR DESCRIPTION
Closes #5 

**Implementation**

1. Push the constants in a constant pool.
2. If operations are performed then write them to string and push them to constant pool.
3. If print is requested then pop from this constant pool and print that with appropriate format specifier (according to left dtype, but this will change when there is implicit typecasting in future).