### PR TITLE
Add walk and compile methods to specific nodes

### DIFF
--- a/langx/compiler/compiler.py
+++ b/langx/compiler/compiler.py
@@ -11,42 +11,8 @@ class Compiler:
     def __init__(self, ast_root):
         self.__ast_root = ast_root
 
-        self.__opcodes = []
-
-    def __check_expr_type_and_walk(self, node, dtype):
-        if type(node) is NumberNode:
-            self.__walk_number(node=node, dtype=dtype)
-        elif type(node) is StringNode:
-            self.__walk_string(node=node, dtype=dtype)
-        elif type(node) is BinaryOperatorNode:
-            self.__walk_binary_operator(node=node, dtype=dtype)
-
-    def __walk_number(self, node, dtype):
-        self.__opcodes.append(OpCode(opcode=OpType.LOAD, op_value=node.value, op_dtype=dtype))
-
-    def __walk_string(self, node, dtype):
-        self.__opcodes.append(OpCode(opcode=OpType.LOAD, op_value=node.value, op_dtype=dtype))
-
-    def __walk_binary_operator(self, node, dtype):
-        self.__check_expr_type_and_walk(node=node.left, dtype=dtype)
-        self.__check_expr_type_and_walk(node=node.right, dtype=dtype)
-
-        self.__opcodes.append(OpCode(opcode=OpType[node.operator], op_value="", op_dtype=""))
-
-    def __walk_expr(self, node):
-        self.__check_expr_type_and_walk(node=node.expr, dtype=node.dtype)
-
-    def __walk_print(self, node):
-        self.__walk_expr(node=node.expr)
-
-        self.__opcodes.append(OpCode(opcode=OpType.PRINT, op_value="", op_dtype=""))
-
-    def __walk_program(self, node):
-        for statement in node.statements:
-            if type(statement) is PrintNode:
-                self.__walk_print(node=statement)
-
     def compile(self):
-        self.__walk_program(node=self.__ast_root)
+        opcodes = []
+        self.__ast_root.walk_and_compile(opcodes)
 
-        return self.__opcodes
+        return opcodes

--- a/langx/parser/node/binary_operator_node.py
+++ b/langx/parser/node/binary_operator_node.py
@@ -1,4 +1,6 @@
 from .node import Node
+from ...opcode.opcode import OpCode
+from ...opcode.op_type import OpType
 
 
 class BinaryOperatorNode(Node):
@@ -46,3 +48,9 @@ class BinaryOperatorNode(Node):
         ast_string += f")\n"
 
         return ast_string
+
+    def walk_and_compile(self, opcodes):
+        self.__left.walk_and_compile(opcodes)
+        self.__right.walk_and_compile(opcodes)
+
+        opcodes.append(OpCode(opcode=OpType[self.__operator], op_value="", op_dtype=""))

--- a/langx/parser/node/expr_node.py
+++ b/langx/parser/node/expr_node.py
@@ -32,3 +32,6 @@ class ExprNode(Node):
         ast_string += f")\n"
 
         return ast_string
+
+    def walk_and_compile(self, opcodes):
+        self.__expr.walk_and_compile(opcodes)

--- a/langx/parser/node/node.py
+++ b/langx/parser/node/node.py
@@ -6,5 +6,9 @@ class Node:
     def walk_and_print(self, tab_level):
         pass
 
+    @abstractmethod
+    def walk_and_compile(self, opcodes):
+        pass
+
     def _add_tabs(self, tab_level):
         return "\t" * tab_level

--- a/langx/parser/node/number_node.py
+++ b/langx/parser/node/number_node.py
@@ -1,9 +1,12 @@
 from .node import Node
+from ...opcode.opcode import OpCode
+from ...opcode.op_type import OpType
 
 
 class NumberNode(Node):
-    def __init__(self, value):
+    def __init__(self, value, dtype):
         self.__value = value
+        self.__dtype = dtype
 
     @property
     def value(self):
@@ -14,3 +17,6 @@ class NumberNode(Node):
         ast_string += f"NumberNode(value={self.__value})\n"
 
         return ast_string
+
+    def walk_and_compile(self, opcodes):
+        opcodes.append(OpCode(opcode=OpType.LOAD, op_value=self.__value, op_dtype=self.__dtype))

--- a/langx/parser/node/print_node.py
+++ b/langx/parser/node/print_node.py
@@ -1,4 +1,6 @@
 from .node import Node
+from ...opcode.opcode import OpCode
+from ...opcode.op_type import OpType
 
 
 class PrintNode(Node):
@@ -21,3 +23,8 @@ class PrintNode(Node):
         ast_string += ")\n"
 
         return ast_string
+
+    def walk_and_compile(self, opcodes):
+        self.__expr.walk_and_compile(opcodes)
+
+        opcodes.append(OpCode(opcode=OpType.PRINT, op_value="", op_dtype=""))

--- a/langx/parser/node/program_node.py
+++ b/langx/parser/node/program_node.py
@@ -23,3 +23,7 @@ class ProgramNode(Node):
             ast_string += statement.walk_and_print(tab_level)
 
         return ast_string
+
+    def walk_and_compile(self, opcodes):
+        for statement in self.__statements:
+            statement.walk_and_compile(opcodes)

--- a/langx/parser/node/string_node.py
+++ b/langx/parser/node/string_node.py
@@ -1,9 +1,12 @@
 from .node import Node
+from ...opcode.opcode import OpCode
+from ...opcode.op_type import OpType
 
 
 class StringNode(Node):
-    def __init__(self, value):
+    def __init__(self, value, dtype):
         self.__value = value
+        self.__dtype = dtype
 
     @property
     def value(self):
@@ -14,3 +17,6 @@ class StringNode(Node):
         ast_string += f"StringNode(value={self.__value})\n"
 
         return ast_string
+
+    def walk_and_compile(self, opcodes):
+        opcodes.append(OpCode(opcode=OpType.LOAD, op_value=self.__value, op_dtype=self.__dtype))

--- a/langx/parser/parser.py
+++ b/langx/parser/parser.py
@@ -32,12 +32,12 @@ class Parser:
     def __string(self):
         string_token = self.__expect("__string__")
 
-        return StringNode(value=string_token.value), "string"
+        return StringNode(value=string_token.value, dtype="string"), "string"
 
     def __number(self):
         number_token = self.__expect("__number__")
 
-        return NumberNode(value=number_token.value), number_token.dtype
+        return NumberNode(value=number_token.value, dtype=number_token.dtype), number_token.dtype
 
     def __term(self):
         if self.__peek().type == "__number__":


### PR DESCRIPTION
Closes #29 
  
**Implementation**
  
1. Add the walk and compile methods to specific nodes.
2. Store the dtype of number and string in their respective nodes too.
3. Use dynamic dispatch to compile the AST. 