### PR TITLE
Move methods to separate file and expose REST endpoints

### DIFF
--- a/langx/webdebug/app.py
+++ b/langx/webdebug/app.py
@@ -1,9 +1,6 @@
 from flask import Flask, request, render_template, jsonify, session
 
-from ..tokenizer.tokenizer import Tokenizer
-from ..parser.parser import Parser
-from ..utils.tree_walker import TreeWalker
-from ..compiler.compiler import Compiler
+from .methods import get_tokens_and_source, get_ast_and_source, get_opcodes_and_source
 
 
 # Instantiate flask app
@@ -26,18 +23,14 @@ def index():
 def generate_tokens():
 
     if request.method == "GET":
-        source_lines = session.get("source").split("\n")
+        source_lines = []
         token_lines = []
-        token_line = ""
-        current_line_number = 1
-        for token in session.get("tokens"):
-            if int(token.split("=")[-1].split(")")[0]) == current_line_number:
-                token_line += f"{str(token)}<br>"
-            else:
-                token_lines.append(token_line)
-                token_line = ""
-                current_line_number += 1
-                token_line += f"{str(token)}<br>"
+
+        for source in session.get("source_tokens"):
+            source_lines.append(source['source'])
+
+        for tokens in session.get("source_tokens"):
+            token_lines.append("<br>".join(tokens['tokens']))
 
         return render_template(
             "tokens.html", source_lines=source_lines, token_lines=token_lines
@@ -46,15 +39,23 @@ def generate_tokens():
     elif request.method == "POST":
         file_path = request.form["file_path"]
 
-        with open(file_path, "r") as f:
-            source = f.read()
+        source_tokens = get_tokens_and_source(file_path=file_path)
 
-        tokens = Tokenizer(source).generate_tokens()
-
-        session["source"] = source
-        session["tokens"] = [str(token) for token in tokens]
+        session["source_tokens"] = source_tokens
 
         return jsonify({"status": "Success", "url": "/generate-tokens"})
+
+
+@app.route("/get-tokens", methods=["POST"])
+def get_tokens():
+
+    if request.method == "POST":
+        data = request.get_json()
+        file_path = data["file_path"]
+
+        source_tokens = get_tokens_and_source(file_path=file_path)
+
+        return jsonify({"source_tokens": source_tokens})
 
 
 @app.route("/generate-ast", methods=["GET", "POST"])
@@ -67,16 +68,24 @@ def generate_ast():
     elif request.method == "POST":
         file_path = request.form["file_path"]
 
-        with open(file_path, "r") as f:
-            source = f.read()
+        ast, source = get_ast_and_source(file_path=file_path)
 
-        tokens = Tokenizer(source).generate_tokens()
-        ast_root = Parser(tokens).parse()
-        ast = TreeWalker(ast_root).walk()
         session["source"] = source
         session["ast"] = ast
 
         return jsonify({"status": "Success", "url": "/generate-ast"})
+
+
+@app.route("/get-ast", methods=[ "POST"])
+def get_ast():
+
+    if request.method == "POST":
+        data = request.get_json()
+        file_path = data["file_path"]
+
+        ast, source = get_ast_and_source(file_path=file_path)
+
+        return jsonify({"ast": ast, "source": source})
 
 
 @app.route("/generate-bytecode", methods=["GET", "POST"])
@@ -91,13 +100,21 @@ def generate_bytecode():
     elif request.method == "POST":
         file_path = request.form["file_path"]
 
-        with open(file_path, "r") as f:
-            source = f.read()
+        opcodes, source = get_opcodes_and_source(file_path=file_path)
 
-        tokens = Tokenizer(source).generate_tokens()
-        ast_root = Parser(tokens).parse()
-        opcodes = Compiler(ast_root).compile()
         session["source"] = source
         session["bytecode"] = "<br>".join([str(opcode) for opcode in opcodes])
 
         return jsonify({"status": "Success", "url": "/generate-bytecode"})
+
+
+@app.route("/get-bytecode", methods=["POST"])
+def get_bytecode():
+
+    if request.method == "POST":
+        data = request.get_json()
+        file_path = data["file_path"]
+
+        opcodes, source = get_opcodes_and_source(file_path=file_path)
+
+        return jsonify({"bytecode": opcodes, "source": source})

--- a/langx/webdebug/methods.py
+++ b/langx/webdebug/methods.py
@@ -1,0 +1,48 @@
+from ..tokenizer.tokenizer import Tokenizer
+from ..parser.parser import Parser
+from ..utils.tree_walker import TreeWalker
+from ..compiler.compiler import Compiler
+
+
+def get_tokens_and_source(file_path):
+    with open(file_path, "r") as f:
+        source = f.read()
+
+    tokens = Tokenizer(source).generate_tokens()
+    source_lines = source.split("\n")
+
+    source_tokens = [{"source": source_line} for source_line in source_lines]
+    current_line_number = 1
+    current_tokens = []
+    for token in tokens:
+        if token.line_num == current_line_number:
+            current_tokens.append(str(token))
+        else:
+            source_tokens[current_line_number - 1]["tokens"] = current_tokens
+            current_line_number = token.line_num
+            current_tokens = [str(token)]
+
+    return source_tokens
+
+
+def get_ast_and_source(file_path):
+    with open(file_path, "r") as f:
+        source = f.read()
+
+    tokens = Tokenizer(source).generate_tokens()
+    ast_root = Parser(tokens).parse()
+    ast = TreeWalker(ast_root).walk()
+
+    return ast, source
+
+
+def get_opcodes_and_source(file_path):
+    with open(file_path, "r") as f:
+        source = f.read()
+
+    tokens = Tokenizer(source).generate_tokens()
+    ast_root = Parser(tokens).parse()
+    opcodes = Compiler(ast_root).compile()
+    opcodes = [str(opcode) for opcode in opcodes]
+
+    return opcodes, source


### PR DESCRIPTION
Closes #41
  
**Implementation**
  
1. Move all the methods to fetch tokens, AST, and bytecode to separate file (langx/webdebug/methods.py).
2. Expose POST endpoints for fetching tokens, AST, and bytecode - `get-tokens`, `get-ast`, and `get-bytecode`.
3. Now to extend XDB run the core XDB server and use these endpoints to write own version of XDB.  